### PR TITLE
Fix imagePullSecrets position

### DIFF
--- a/charts/draftt-explorer/Chart.yaml
+++ b/charts/draftt-explorer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: draftt-explorer
 description: A Helm chart for Draftt k8s explorer
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.0.1"

--- a/charts/draftt-explorer/templates/cronjob.yaml
+++ b/charts/draftt-explorer/templates/cronjob.yaml
@@ -19,10 +19,6 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: {{ .Values.cronjob.maxRetries }}
-      {{- if .Values.cronjob.image.pullSecrets }}
-      imagePullSecrets:
-      {{- toYaml .Values.cronjob.image.pullSecrets | nindent 8 }}
-      {{- end }}
       template:
         metadata:
           labels:
@@ -35,6 +31,10 @@ spec:
               {{- toYaml .Values.cronjob.annotations | nindent 12 }}
             {{- end }}
         spec:
+          {{- if .Values.cronjob.image.pullSecrets }}
+          imagePullSecrets:
+          {{- toYaml .Values.cronjob.image.pullSecrets | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
           containers:
           - name: draftt-k8s-explorerrer


### PR DESCRIPTION
**What this PR does / why we need it**

Having the image repository configured to our `jFrog` mirror requires `imagePullSecrets` configured, however, the current template results in this error:
```
Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: .spec.jobTemplate.spec.imagePullSecrets: field not declared in schema
```

The `imgePullSecrets` should be under the `podSpec` 
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
```
apiVersion: batch/v1
kind: CronJob
spec:
  jobTemplate:
    spec:
      template:
        spec:
          imagePullSecrets:
            - secretName
``` 