### PR TITLE
chore(draftt-port-integration): bump image to 0.0.4

### DIFF
--- a/charts/draftt-port-integration/Chart.yaml
+++ b/charts/draftt-port-integration/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: draftt-port-integration
 description: A Helm chart for Draftt - Port.io integration
-version: 0.1.0
-appVersion: "0.0.1"
+version: 0.1.1
+appVersion: "0.0.4"

--- a/charts/draftt-port-integration/README.md
+++ b/charts/draftt-port-integration/README.md
@@ -1,6 +1,6 @@
 # draftt-port-integration
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.0.4](https://img.shields.io/badge/AppVersion-0.0.4-informational?style=flat-square)
 
 A Helm chart for Draftt - Port.io integration
 
@@ -41,5 +41,5 @@ To uninstall the chart:
 | image.pullPolicy | string | `"Always"` | Image pull policy to use for the Draftt port integration |
 | image.pullSecrets | list | `[]` | Pull secrets to pull images from a private registry |
 | image.repository | string | `"public.ecr.aws/draftt-io/draftt-port-integration"` | Repository to use for the Draftt port integration |
-| image.tag | string | `"0.0.1"` | Tag to use for the Draftt port integration |
+| image.tag | string | `"0.0.4"` | Tag to use for the Draftt port integration |
 | nameOverride | string | `""` | Override the chart name |

--- a/charts/draftt-port-integration/values.yaml
+++ b/charts/draftt-port-integration/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Repository to use for the Draftt port integration
   repository: public.ecr.aws/draftt-io/draftt-port-integration
   # -- Tag to use for the Draftt port integration
-  tag: 0.0.1
+  tag: 0.0.4
   # -- Image pull policy to use for the Draftt port integration
   pullPolicy: Always
   # -- Pull secrets to pull images from a private registry


### PR DESCRIPTION
Points the `draftt-port-integration` chart at the newly published `0.0.4` image (previously `0.0.1`).

## Changes
- `values.yaml`: `image.tag` `0.0.1` → `0.0.4`
- `Chart.yaml`: `appVersion` `0.0.1` → `0.0.4`, chart `version` `0.1.0` → `0.1.1`
- `README.md`: regenerated version badges + `image.tag` doc

`0.0.4` is live and multi-arch (linux/amd64 + linux/arm64) at `public.ecr.aws/draftt-io/draftt-port-integration:0.0.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)